### PR TITLE
Use cache for image

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -92,6 +92,8 @@ http {
             add_header Cache-Control public;
           }
           location /icons/ { 
+            expires 24h;
+            add_header Cache-Control public;
           }
 
           location / {


### PR DESCRIPTION
`1907` までスコアが落ちてしまった。。。
もしかすると、「同じ名前の画像のアップロード」が行われて、cache すると間違いになってる。。。？

`master` にチェックアウトすると `18,000` まで戻ったので、やはりこの変更が問題っぽい。永田君に「ユニークなファイル名」生成をやってもらってる。